### PR TITLE
Improved CoGym Gemini Compatibility

### DIFF
--- a/collaborative_gym/server.py
+++ b/collaborative_gym/server.py
@@ -45,7 +45,7 @@ app = FastAPI()
 # Set up CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://co-gym.com", "http://localhost:3000"],
+    allow_origins=["https://co-gym.com", "http://localhost:3000", "http://localhost:3001"],
     allow_credentials=True,
     allow_methods=["*"],  # Allows all methods
     allow_headers=["*"],  # Allows all headers

--- a/frontend/workbench/app/(session)/layout.tsx
+++ b/frontend/workbench/app/(session)/layout.tsx
@@ -27,33 +27,31 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={cn(
-          'font-sans antialiased',
-          GeistSans.variable,
-          GeistMono.variable
-        )}
+    <div
+      className={cn(
+        'font-sans antialiased',
+        GeistSans.variable,
+        GeistMono.variable
+      )}
+    >
+      <Providers
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
       >
-        <Providers
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-         <div className="flex min-h-screen">
-            {/* Sidebar */}
-            <VerticalMenu />
-            {/* Divider */}
-            <div className="w-px bg-divider"></div>
-            {/* Main Content */}
-            <main className="flex-1 flex flex-col">
-              {children}
-            </main>
-          </div>
-          <TailwindIndicator />
-        </Providers>
-      </body>
-    </html>
+        <div className="flex min-h-screen">
+          {/* Sidebar */}
+          <VerticalMenu />
+          {/* Divider */}
+          <div className="w-px bg-divider"></div>
+          {/* Main Content */}
+          <main className="flex-1 flex flex-col">
+            {children}
+          </main>
+        </div>
+        <TailwindIndicator />
+      </Providers>
+    </div>
   )
 }

--- a/frontend/workbench/app/layout.tsx
+++ b/frontend/workbench/app/layout.tsx
@@ -16,8 +16,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body>{children}</body>
-      <Toaster />
+      <body>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/frontend/workbench/components/teammate/teammate-state-window.tsx
+++ b/frontend/workbench/components/teammate/teammate-state-window.tsx
@@ -47,7 +47,7 @@ export function TeammateStateWindow({ envId, teammateState }: TeammateStateWindo
 
   return (
     <div className="flex items-center space-x-4 h-1/9">
-      <div className="relative h-full flex items-center">
+      <div className="relative h-full flex items-center" style={{ width: 'auto', aspectRatio: "1 / 1" }}>
         <Tooltip title="Click to see agent state details.">
           <Avatar
             src="/avatar.svg"

--- a/secrets.example.toml
+++ b/secrets.example.toml
@@ -2,6 +2,8 @@
 OPENAI_API_KEY = "your_openai_api_key"
 # If you need to use Claude models
 ANTHROPIC_API_KEY = ""
+# If you need to use Google Gemini
+GEMINI_API_KEY = ""
 # If you need to use together.ai inference services for open-weight LMs
 TOGETHER_API_KEY = ""
 # If you need real-time search for travel planning task in Co-Gym (Real)


### PR DESCRIPTION
This pull request introduces several improvements across the backend, frontend, and configuration files. The major focus is on making action parsing and validation more robust, improving frontend layout for more screens, enhancing agent parsing logic, and updating configuration for API keys and development environments.

**Backend improvements:**

* Improved action parsing and validation in `collaborative_gym/core.py` to more robustly handle edge cases, such as extra whitespace, embedded prose, or malformed actions, ensuring actions are sanitized and correctly matched against private and public action spaces. [[1]](diffhunk://#diff-f0726af9d13d25906ffe23615619735a6ae0c8a6587f7c19983af9658f17671fL130-R193) [[2]](diffhunk://#diff-f0726af9d13d25906ffe23615619735a6ae0c8a6587f7c19983af9658f17671fL144-R205)
* Importantly Gemini with the default prompt tends to output actions in the middle of responses without Action: indicators so this version of parsing handles those types of responses better.

**Frontend and UI enhancements:**

* Changed the top-level wrapper in `frontend/workbench/app/(session)/layout.tsx` from `<html><body>` to a `<div>`, simplifying the layout structure and improving hydration and rendering behavior. [[1]](diffhunk://#diff-d031857279d667d1fb24d193fc6ffc97c1d6a2e981ddbe413a07d9e35c65c3fcL30-R30) [[2]](diffhunk://#diff-d031857279d667d1fb24d193fc6ffc97c1d6a2e981ddbe413a07d9e35c65c3fcL56-R55)
* Updated the text extraction logic in `ConfirmationOverlay` to more robustly parse the content inside `EDITOR_UPDATE(text=...)`, supporting multi-line and optionally quoted content.
* Added explicit width and aspect ratio to the avatar container in `TeammateStateWindow` for consistent UI appearance.
* Ensured the `Toaster` component is always rendered inside the `<body>` in `frontend/workbench/app/layout.tsx`.

**Configuration and development environment:**

* Added `http://localhost:3001` to CORS allowed origins in `collaborative_gym/server.py` to support additional local development setups.  I'm not partial to this change though and happy to revert.  Basically `pnpm dev` auto-shifts to 3001 if 3001 is taken and in my case it was.
* Added `GEMINI_API_KEY` to `secrets.example.toml` for Google Gemini model integration.